### PR TITLE
feat: write generated output to files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /**/package-lock.json
 /**/dist/
 /package/
+/examples/output

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -7,8 +7,13 @@ async function generateTypescript() {
   generate({
     input: "examples/input.yaml",
     output: {
+      cleanWrite: true,
       fileExtension: ".ts",
-      directory: "examples/output/"
+      directory: "examples/output",
+      writerMode: {
+        groupedTypes: 'FolderWithFiles', 
+        types: 'SingleFile'
+      }
     },
     template: {
       objectSyntax

--- a/examples/input.yaml
+++ b/examples/input.yaml
@@ -3,7 +3,28 @@ info:
   title: Sample Typing Spec
 groupedTypes:
   GroupOne:
-    SampleObjectOne:
+    GroupObjectOne:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+  GroupTwo:
+    GroupTwoObjectOne:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    GroupTwoObjectTwo:
       type: object
       required:
         - id
@@ -14,7 +35,27 @@ groupedTypes:
         name:
           type: string
 types:
-  SampleObjectTwo:
+  TypeObjectTwo:
+    type: object
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+  TypeObjectThree:
+    type: object
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+  TypeObjectFour:
     type: object
     required:
       - id

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yaml from "yaml";
 import { Configuration, decodeSpecFileData } from "$types";
-import { readFile } from "$utils";
+import { readFile, writeOutput } from "$utils";
 import { generator } from "$generators/generic";
 
 export async function generate(config: Configuration): Promise<void> {
@@ -11,7 +11,8 @@ export async function generate(config: Configuration): Promise<void> {
     if (decodedSpecData === null) {
       throw new Error("Invalid spec file data!");
     }
-    generator(config, decodedSpecData);
+    const result = generator(config, decodedSpecData);
+    await writeOutput(config, result);
   } catch (e) {
     console.error("Generation failed!");
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,8 +10,13 @@ export type Configuration = {
 };
 
 export type OutputConfig = {
+  cleanWrite: boolean;
   fileExtension: string;
   directory: string;
+  writerMode: {
+    groupedTypes: 'FolderWithFiles' | 'SingleFile';
+    types: 'SingleFile' | 'Files';
+  }
 }
 
 export type Template = {

--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -22,6 +22,14 @@ export async function createFolder(basePath: string, folderName: string) {
   await fs.mkdir(folderPath, { recursive: true });
 }
 
+export async function _createFolder(folderPath: string) {
+  await fs.mkdir(folderPath, { recursive: true });
+}
+
+export async function deleteFolder(folderPath: string) {
+  await fs.rmdir(folderPath, { recursive: true });
+}
+
 export async function writeFile(
   basePath: string,
   fileName: string,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,47 @@
-export * from "./fs";
+import { Configuration, GenerationResult, TypesOutput } from "$types";
+import { _createFolder, createFolder, deleteFolder, writeFile } from "./file-system";
+
+export * from "./file-system";
+
+async function writeTypesToFiles(config: Configuration, types: TypesOutput, folderName: string = '') { 
+  for (let typeName in types) { 
+    await writeFile(config.output.directory + '/' + folderName, typeName + config.output.fileExtension, types[typeName]);
+  }
+}
+
+async function writeTypesToSingleFile(config: Configuration, types: TypesOutput, fileName: string = 'types') { 
+  let content = '';
+  for (let typeName in types) { 
+    content += types[typeName] + '\n';
+  }
+  await writeFile(config.output.directory,  fileName + config.output.fileExtension, content);
+}
+
+
+export async function writeOutput(config: Configuration, generationResult: GenerationResult) { 
+  if (config.output.cleanWrite) { 
+    await deleteFolder(config.output.directory);
+  }
+
+  await _createFolder(config.output.directory);
+
+  // writing types to output directory
+  if (config.output.writerMode.types === 'Files') { 
+    await writeTypesToFiles(config, generationResult.types)
+  } else if (config.output.writerMode.types === 'SingleFile') { 
+    await writeTypesToSingleFile(config, generationResult.types);
+  }
+
+  // writing grouped types to output directory
+  if (config.output.writerMode.groupedTypes === 'FolderWithFiles') { 
+    for (let groupName in generationResult.groupedTypes) { 
+      await createFolder(config.output.directory, groupName);
+      await writeTypesToFiles(config, generationResult.groupedTypes[groupName], groupName);
+    }
+  } else if (config.output.writerMode.groupedTypes === 'SingleFile') { 
+    for (let groupName in generationResult.groupedTypes) { 
+      await writeTypesToSingleFile(config, generationResult.groupedTypes[groupName], groupName);
+    }
+  }
+
+}


### PR DESCRIPTION
- added support for writing generated types to files
- added configuration for writing types & grouped types in different formats
- added support for clean writing (delete previously generated output & write new files)
- renamed fs.ts to file-system.ts to avoid conflicts existing node lib
- ignored examples/output