### PR TITLE
feat: add support for $ref types

### DIFF
--- a/examples/index.ts
+++ b/examples/index.ts
@@ -4,6 +4,7 @@ import { generate } from '../src';
 async function generateTypescript(): Promise<void> {
   const objectSyntax = await readFile('templates/typescript/object-syntax.hbs');
   const exporterModuleSyntax = await readFile('templates/typescript/exporter-module-syntax.hbs');
+  const typesFileSyntax = await readFile('templates/typescript/types-file-syntax.hbs');
 
   await generate({
     input: 'examples/input.yaml',
@@ -13,12 +14,13 @@ async function generateTypescript(): Promise<void> {
       directory: 'examples/output',
       writerMode: {
         groupedTypes: 'FolderWithFiles',
-        types: 'Files'
+        types: 'SingleFile'
       }
     },
     template: {
       objectSyntax,
-      exporterModuleSyntax
+      exporterModuleSyntax,
+      typesFileSyntax
     },
     language: {
       exporterModuleName: 'index',
@@ -28,7 +30,8 @@ async function generateTypescript(): Promise<void> {
         integer: { default: 'integer' },
         boolean: 'boolean',
         array: '~ItemType~[]',
-        object: 'type'
+        object: 'type',
+        unknown: 'unknown'
       }
     }
   });

--- a/examples/input.yaml
+++ b/examples/input.yaml
@@ -13,6 +13,18 @@ groupedTypes:
           type: string
         name:
           type: string
+        refT:
+          $ref: '#/types/TypeObjectTwo'
+    GroupObjectTwo:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
   GroupTwo:
     GroupTwoObjectOne:
       type: object
@@ -40,11 +52,26 @@ types:
     required:
       - id
       - name
+      - groupProperty
     properties:
       id:
         type: string
       name:
         type: string
+      random:
+        type: unknown
+      recType:
+        type: object
+        properties:
+          recId:
+            type: string
+          recName:
+            type: number
+          recDate:
+            type: string
+            format: date
+      refType:
+        $ref: '#/types/TypeObjectThree'
   TypeObjectThree:
     type: object
     required:
@@ -55,7 +82,23 @@ types:
         type: string
       name:
         type: string
+      refType2:
+        $ref: '#/groupedTypes/GroupOne/GroupObjectOne'
+      refType3:
+        $ref: '#/groupedTypes/GroupTwo/GroupTwoObjectOne'
+      refType22:
+        $ref: '#/types/TypeObjectFive'
   TypeObjectFour:
+    type: object
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+  TypeObjectFive:
     type: object
     required:
       - id

--- a/src/generators/helpers.ts
+++ b/src/generators/helpers.ts
@@ -1,0 +1,28 @@
+import Runtime from '$runtime';
+import { readNestedValue } from '$utils';
+import type { JSONObject } from 'type-decoder';
+
+export function resolveReference(reference: string): JSONObject {
+  let referenceType: 'local' | 'remote' | 'url' | 'unknown' = 'unknown';
+  const referenceParts = reference.split('/');
+
+  if (reference.startsWith('#')) {
+    referenceType = 'local';
+  } else if (reference.startsWith('http')) {
+    referenceType = 'url';
+  } else {
+    referenceType = 'remote';
+  }
+
+  if (referenceType === 'local') {
+    const specFileData = Runtime.getSpecFileData();
+    const referenceKeyPath = referenceParts.slice(1);
+    return readNestedValue(specFileData, referenceKeyPath);
+  } else if (referenceType === 'url') {
+    throw new Error('URL references are not supported yet');
+  } else if (referenceType === 'remote') {
+    throw new Error('Remote references are not supported yet');
+  } else {
+    throw new Error('Invalid reference');
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 import yaml from 'yaml';
 import { type Configuration, decodeSpecFileData } from '$types';
-import { getOptionalKeys, readFile } from '$utils';
+import { readFile, registerTemplateHelpers } from '$utils';
 import { generator } from '$generators/generic';
 import { writeOutput } from '$writer';
-import Handlebars from 'handlebars';
-import Runtime from './runtime';
+import Runtime from '$runtime';
 
 export async function generate(config: Configuration): Promise<void> {
   try {
@@ -12,13 +11,18 @@ export async function generate(config: Configuration): Promise<void> {
     const specFileData = await readFile(config.input);
     const specJSONData = yaml.parse(specFileData);
     const decodedSpecData = decodeSpecFileData(specJSONData);
-    if (decodedSpecData === null) {
+    if (
+      decodedSpecData === null ||
+      (decodedSpecData.types === null && decodedSpecData.groupedTypes === null)
+    ) {
       throw new Error('Invalid spec file data!');
     }
-    Handlebars.registerHelper('getOptionalKeys', getOptionalKeys);
+    Runtime.setSpecFileData(decodedSpecData);
+    Runtime.compileTemplates();
+    registerTemplateHelpers();
     const result = generator(decodedSpecData);
     await writeOutput(result);
   } catch (e) {
-    console.error('Generation failed!');
+    console.error('Generation failed!: ', String(e));
   }
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,6 +1,20 @@
-import type { Configuration } from '$types';
+import type {
+  Configuration,
+  ExporterModuleTemplateInput,
+  ObjectTemplateInput,
+  SpecFileData,
+  TypeFilePath,
+  TypesFileTemplateInput
+} from '$types';
+import Handlebars from 'handlebars';
 
 let config: Configuration | null = null;
+let specFileData: SpecFileData | null = null;
+let objectSyntaxTemplate: HandlebarsTemplateDelegate<ObjectTemplateInput> | null = null;
+let exporterModuleSyntaxTemplate: HandlebarsTemplateDelegate<ExporterModuleTemplateInput> | null =
+  null;
+let typesFileSyntaxTemplate: HandlebarsTemplateDelegate<TypesFileTemplateInput> | null = null;
+let expectedOutputFiles: Map<string, TypeFilePath> | null = null;
 
 function setConfig(newConfig: Configuration): void {
   config = newConfig;
@@ -13,7 +27,65 @@ function getConfig(): Configuration {
   return config;
 }
 
+function setSpecFileData(newSpecFileData: SpecFileData): void {
+  specFileData = newSpecFileData;
+}
+
+function getSpecFileData(): SpecFileData {
+  if (specFileData === null) {
+    throw new Error('Spec file data not set!');
+  }
+  return specFileData;
+}
+
+function compileTemplates(): void {
+  const config = getConfig();
+  objectSyntaxTemplate = Handlebars.compile(config.template.objectSyntax);
+  exporterModuleSyntaxTemplate = Handlebars.compile(config.template.exporterModuleSyntax);
+  typesFileSyntaxTemplate = Handlebars.compile(config.template.typesFileSyntax);
+}
+
+function getObjectTemplate(): HandlebarsTemplateDelegate<ObjectTemplateInput> {
+  if (objectSyntaxTemplate === null) {
+    throw new Error('Object template not compiled!');
+  }
+  return objectSyntaxTemplate;
+}
+
+function getExporterModuleTemplate(): HandlebarsTemplateDelegate<ExporterModuleTemplateInput> {
+  if (exporterModuleSyntaxTemplate === null) {
+    throw new Error('Exporter module template not compiled!');
+  }
+  return exporterModuleSyntaxTemplate;
+}
+
+function getTypesFileTemplate(): HandlebarsTemplateDelegate<TypesFileTemplateInput> {
+  if (typesFileSyntaxTemplate === null) {
+    throw new Error('Types file template not compiled!');
+  }
+  return typesFileSyntaxTemplate;
+}
+
+function setExpectedOutputFiles(newExpectedOutputFiles: Map<string, TypeFilePath>): void {
+  expectedOutputFiles = newExpectedOutputFiles;
+}
+
+function getExpectedOutputFiles(): Map<string, TypeFilePath> {
+  if (expectedOutputFiles === null) {
+    throw new Error('Expected output files not set!');
+  }
+  return expectedOutputFiles;
+}
+
 export default {
   getConfig,
-  setConfig
+  setConfig,
+  setSpecFileData,
+  setExpectedOutputFiles,
+  getSpecFileData,
+  getObjectTemplate,
+  getExporterModuleTemplate,
+  getTypesFileTemplate,
+  getExpectedOutputFiles,
+  compileTemplates
 };

--- a/src/types/decoders.ts
+++ b/src/types/decoders.ts
@@ -85,22 +85,15 @@ function decodeTypes(rawInput: unknown): Types | null {
 
 function decodeTypeInfo(rawInput: unknown): TypeInfo | null {
   if (isJSON(rawInput)) {
-    const required = decodeArray(rawInput.required, decodeString);
-    const properties = decodeTypeProperties(rawInput.properties);
-    const _type = decodeTypeDataType(rawInput.type);
-    const items = decodeTypeInfo(rawInput.items);
-    if (_type !== null) {
-      const result: TypeInfo = {
-        type: _type,
-        required,
-        properties,
-        items,
-        format: decodeString(rawInput.format)
-      };
-      if (noErrorOrNullValues(result, ['required', 'properties', 'items', 'format'])) {
-        return result;
-      }
-    }
+    const result: TypeInfo = {
+      type: decodeTypeDataType(rawInput.type),
+      required: decodeArray(rawInput.required, decodeString),
+      properties: decodeTypeProperties(rawInput.properties),
+      items: decodeTypeInfo(rawInput.items),
+      format: decodeString(rawInput.format),
+      $ref: decodeString(rawInput.$ref)
+    };
+    return result;
   }
   return null;
 }
@@ -131,6 +124,7 @@ function decodeTypeDataType(rawInput: unknown): TypeDataType | null {
       case 'boolean':
       case 'array':
       case 'object':
+      case 'unknown':
         return rawInput;
     }
   }
@@ -141,10 +135,12 @@ function decodeObjectTemplateInputProperty(rawInput: unknown): ObjectTemplateInp
   if (isJSON(rawInput)) {
     const required = decodeBoolean(rawInput.required);
     const _type = decodeString(rawInput.type);
-    if (required !== null && _type !== null) {
+    const referenced = decodeBoolean(rawInput.referenced);
+    if (required !== null && _type !== null && referenced !== null) {
       return {
         type: _type,
-        required
+        required,
+        referenced
       };
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export type OutputConfig = {
 export type Template = {
   objectSyntax: string;
   exporterModuleSyntax: string;
+  typesFileSyntax: string;
 };
 
 export type LanguageConfig = {
@@ -63,16 +64,24 @@ export type Types = Record<TypeName, TypeInfo>;
 
 export type TypeInfo = {
   required: string[] | null;
-  type: TypeDataType;
+  type: TypeDataType | null;
   format: string | null;
   items: TypeInfo | null;
   properties: TypeProperties | null;
+  $ref: string | null;
 };
 
 type PropertyName = string;
 export type TypeProperties = Record<PropertyName, TypeInfo>;
 
-export type TypeDataType = 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object';
+export type TypeDataType =
+  | 'string'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'array'
+  | 'object'
+  | 'unknown';
 
 // #endregion
 
@@ -88,10 +97,24 @@ export type ObjectTemplateInputProperties = Record<PropertyName, ObjectTemplateI
 export type ObjectTemplateInputProperty = {
   type: string;
   required: boolean;
+  referenced: boolean;
 };
 
 export type ExporterModuleTemplateInput = {
   modules: string[];
+};
+
+export type TypesFileTemplateInput = {
+  referencedTypes: string[];
+  primitives: string[];
+  typesContent: string;
+  writtenAt: string;
+};
+
+export type ReferencedModule = {
+  modulePath: string;
+  moduleRelativePath: string;
+  referencedTypes: string[];
 };
 
 // #endregion
@@ -100,10 +123,16 @@ export type ExporterModuleTemplateInput = {
 
 export type GenerationResult = {
   groupedTypes: GroupedTypesOutput;
-  types: TypesOutput;
+  types: GeneratedTypes;
 };
+export type GeneratedType = { content: string; references: Set<string>; primitives: Set<string> };
+export type GroupedTypesOutput = Record<GroupName, GeneratedTypes>;
+export type GeneratedTypes = Record<TypeName, GeneratedType>;
 
-export type GroupedTypesOutput = Record<GroupName, TypesOutput>;
-export type TypesOutput = Record<TypeName, string>;
+export type TypeFilePath = {
+  modulePath: string;
+  filePath: string;
+  extension: string;
+};
 
 // #endregion

--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-function resolveFilePath(filePath: string): string {
+export function resolveFilePath(filePath: string): string {
   const isAbsolutePath = path.isAbsolute(filePath);
   const normalizedPath = isAbsolutePath ? filePath : path.join(process.cwd(), filePath);
   return path.resolve(normalizedPath);
@@ -39,6 +39,14 @@ export async function getCompleteFolderPath(folderName: string): Promise<string>
     return folderPath.slice(0, -1);
   }
   return folderPath;
+}
+
+export async function getExpectedWrittenPath(basePath: string, fileName: string): Promise<string> {
+  const isAbsolutePath = path.isAbsolute(basePath);
+  const filePath = isAbsolutePath
+    ? path.join(basePath, fileName)
+    : path.join(process.cwd(), basePath, fileName);
+  return filePath;
 }
 
 export async function writeFile(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,8 @@
-import { decodeObjectTemplateInputProperties } from '$types';
+import { type ReferencedModule, decodeObjectTemplateInputProperties } from '$types';
+import Handlebars from 'handlebars';
+import { type JSONObject, type JSONValue, decodeArray, decodeString, isJSON } from 'type-decoder';
+import Runtime from '$runtime';
+import { resolveFilePath } from './file-system';
 
 export * from './file-system';
 
@@ -30,9 +34,105 @@ export function getOptionalKeys(object: unknown): string[] {
   return nullableKeys;
 }
 
+export function getReferencedTypes(object: unknown): string[] {
+  const referencedTypes = [];
+  const properties = decodeObjectTemplateInputProperties(object);
+  if (properties !== null) {
+    for (const propertyName in properties) {
+      const property = properties[propertyName];
+      if (property.referenced) {
+        referencedTypes.push(property.type);
+      }
+    }
+  }
+  return referencedTypes;
+}
+
+export function getReferencedTypeModules(_referencedTypes: unknown, _writtenAt: string): unknown[] {
+  const referencedTypes = decodeArray(_referencedTypes, decodeString);
+  const writtenAt = decodeString(_writtenAt);
+  if (referencedTypes === null || writtenAt === null) {
+    return [];
+  }
+
+  const expectedOutputFiles = Runtime.getExpectedOutputFiles();
+  const referencedTypeModules: Record<string, ReferencedModule> = {};
+
+  for (const referenceType of referencedTypes) {
+    const outputFile = expectedOutputFiles.get(referenceType);
+    if (
+      typeof outputFile !== 'undefined' &&
+      resolveFilePath(outputFile.filePath) !== resolveFilePath(writtenAt)
+    ) {
+      if (typeof referencedTypeModules[outputFile.modulePath] === 'undefined') {
+        referencedTypeModules[outputFile.modulePath] = {
+          modulePath: outputFile.modulePath,
+          moduleRelativePath: generateRelativePath(writtenAt, outputFile.modulePath),
+          referencedTypes: [referenceType]
+        };
+      } else {
+        referencedTypeModules[outputFile.modulePath].referencedTypes.push(referenceType);
+      }
+    }
+  }
+
+  const result: ReferencedModule[] = [];
+  for (const modulePath in referencedTypeModules) {
+    result.push(referencedTypeModules[modulePath]);
+  }
+  return result;
+}
+
 export function toPascalCase(input: string): string {
   return input
     .split(/[-_]/)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join('');
 }
+
+export function registerTemplateHelpers(): void {
+  Handlebars.registerHelper('getOptionalKeys', getOptionalKeys);
+  Handlebars.registerHelper('getReferencedTypes', getReferencedTypes);
+  Handlebars.registerHelper('getReferencedTypeModules', getReferencedTypeModules);
+}
+
+export function readNestedValue(json: JSONObject, keyPath: string[]): JSONObject {
+  let result: JSONValue = json;
+  keyPath.forEach((key) => {
+    if (isJSON(result)) {
+      result = result[key];
+    } else {
+      throw new Error('Invalid Key Path for: ' + keyPath.join('.'));
+    }
+  });
+  return result;
+}
+
+export function generateRelativePath(fromPath: string, toPath: string): string {
+  fromPath = stripPrefix(resolveFilePath(fromPath), '/');
+  toPath = stripPrefix(resolveFilePath(toPath), '/');
+  const fromPathArray = fromPath.split('/');
+  const toPathArray = toPath.split('/');
+
+  let diffIndex = -1;
+
+  for (let i = 0; i < toPathArray.length; i++) {
+    if (fromPathArray[i] !== toPathArray[i]) {
+      diffIndex = i;
+      break;
+    }
+  }
+
+  let pathPrefix = Array(fromPathArray.length - diffIndex).join('../');
+  pathPrefix = pathPrefix === '' ? './' : pathPrefix;
+
+  return pathPrefix + toPathArray.slice(diffIndex).join('/');
+}
+
+// #region string utils
+
+export function stripPrefix(value: string, prefix: string): string {
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+// #endregion

--- a/src/writer/helpers.ts
+++ b/src/writer/helpers.ts
@@ -1,0 +1,51 @@
+import Runtime from '$runtime';
+import type { TypeFilePath, Types } from '$types';
+
+export function generateTypesOutputFiles(
+  types: Types | null,
+  groupName: string | null = null
+): Map<string, TypeFilePath> {
+  const config = Runtime.getConfig();
+  const extension = config.output.fileExtension;
+  const outputDir = config.output.directory;
+  const moduleFileName = config.language.exporterModuleName;
+  const writerMode =
+    groupName === null ? config.output.writerMode.types : config.output.writerMode.groupedTypes;
+
+  const result: Map<string, TypeFilePath> = new Map<string, TypeFilePath>();
+
+  for (const typeName in types) {
+    const typeProperties = types[typeName];
+    if (typeof typeProperties !== 'undefined') {
+      result.set(typeName, {
+        modulePath:
+          outputDir +
+          '/' +
+          (writerMode === 'FolderWithFiles' ? (groupName ?? '') + '/' : '') +
+          moduleFileName,
+        filePath:
+          outputDir +
+          (writerMode === 'Files' || writerMode === 'FolderWithFiles'
+            ? '/' + (groupName ?? '') + typeName
+            : '/' + (groupName ?? 'types')),
+        extension
+      });
+    }
+  }
+  return result;
+}
+
+export function generateExpectedOutputFile(): Map<string, TypeFilePath> {
+  const specData = Runtime.getSpecFileData();
+
+  let result: Map<string, TypeFilePath> = new Map<string, TypeFilePath>();
+
+  result = new Map([...generateTypesOutputFiles(specData.types)]);
+
+  for (const groupName in specData.groupedTypes) {
+    const group = specData.groupedTypes[groupName];
+    result = new Map([...result, ...generateTypesOutputFiles(group, groupName)]);
+  }
+
+  return result;
+}

--- a/templates/typescript/exporter-module-syntax.hbs
+++ b/templates/typescript/exporter-module-syntax.hbs
@@ -1,3 +1,3 @@
 {{#each modules}}
-  export * from './{{this}}';
+export * from './{{this}}';
 {{/each}}

--- a/templates/typescript/types-file-syntax.hbs
+++ b/templates/typescript/types-file-syntax.hbs
@@ -1,0 +1,5 @@
+{{#each (getReferencedTypeModules referencedTypes writtenAt)}}
+import type { {{{this.referencedTypes}}} } from '{{this.moduleRelativePath}}';
+{{/each}}
+
+{{{typesContent}}}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,9 @@
       "$generators": ["./src/generators"],
       "$generators/*": ["./src/generators/*"],
       "$writer": ["./src/writer"],
-      "$writer/*": ["./src/writer/*"]
+      "$writer/*": ["./src/writer/*"],
+      "$runtime": ["./src/runtime"],
+      "$runtime/*": ["./src/runtime/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */


### PR DESCRIPTION
- migrated specFileData, compiled templates, expected output files to runtime
- added support for referencing across types
  - added utils for resolving references & reference type
  - updated object writer input to contain primitive & referenced data types
  - read static values from runtime
  - added key $ref support in type
- added new template for typesFileSyntax for writing type files
- typed data for variable types & included unknown
- added util fn to generate expected output files
- updated ts templates