### PR TITLE
ci: fix access for published npm package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "release",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/package.json
+++ b/package.json
@@ -22,7 +22,14 @@
     "publish": "node scripts/publish.js",
     "changeset:version": "changeset version && git add --all"
   },
-  "keywords": [],
+  "keywords": [
+    "type-crafter",
+    "types",
+    "crafter",
+    "generation",
+    "generator",
+    "typescript"
+  ],
   "author": "Sahil Sinha",
   "license": "ISC",
   "exports": {


### PR DESCRIPTION
- made published node package access to public
- added tag option to the publish trigger