### PR TITLE
feat: added support for generating ts types with decoders

### DIFF
--- a/.changeset/curly-badgers-lie.md
+++ b/.changeset/curly-badgers-lie.md
@@ -1,0 +1,7 @@
+---
+'type-crafter': minor
+---
+
+feat: added support for generating typescript types with decoders
+
+- now generate typescript types with decoders using `typescript-with-decoders` language param

--- a/examples/input.yaml
+++ b/examples/input.yaml
@@ -88,7 +88,24 @@ types:
         $ref: '#/groupedTypes/GroupTwo/GroupTwoObjectOne'
       refType22:
         $ref: '#/types/TypeObjectFive'
+
+  NonRequiredType:
+    type: object
+    properties:
+      id:
+        type: string
+      name:
+        type: string
   TypeObjectFour:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+  SampleObjectOne:
     type: object
     required:
       - id
@@ -103,11 +120,16 @@ types:
     required:
       - id
       - name
+      - refProperty
     properties:
       id:
         type: string
       name:
         type: string
+      refProperty:
+        $ref: '#/types/TypeObjectFour'
+      refProperty2:
+        $ref: '#/types/SampleObjectOne'
       itemRefArr:
         type: array
         items:

--- a/src/generators/generic.ts
+++ b/src/generators/generic.ts
@@ -94,6 +94,8 @@ function generateType(
       throw new InvalidSpecFileError('Invalid property type for: ' + typeName + '.' + propertyName);
     }
 
+    const primitiveType = propertyType ?? 'object';
+    let composerType = null;
     let recursivePropertyName;
     let languageDataType: string | null = null;
     let isReferenced = false;
@@ -120,7 +122,12 @@ function generateType(
       }
     } else if (propertyType !== null) {
       languageDataType = getLanguageDataType(propertyType, propertyFormat, propertyItems);
-      result.primitives.add(languageDataType);
+      result.primitives.add(propertyItems !== null ? 'Array' : languageDataType);
+      if (propertyItems !== null) {
+        const itemsType = getReferenceName(propertyItems.$ref ?? '');
+        result.references.add(itemsType);
+        composerType = itemsType;
+      }
     }
 
     if (languageDataType === null) {
@@ -132,7 +139,9 @@ function generateType(
       [propertyName]: {
         type: languageDataType,
         required: typeInfo.required?.includes(propertyName) ?? false,
-        referenced: isReferenced
+        referenced: isReferenced,
+        primitiveType,
+        composerType
       }
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {
 import { generator } from '$generators/generic';
 import { writeOutput } from '$writer';
 import Runtime from '$runtime';
-import { typescript } from '$templates';
+import { typescript, typescriptWithDecoders } from '$templates';
 
 export async function generate(config: Configuration): Promise<void> {
   Runtime.setConfig(config);
@@ -62,6 +62,14 @@ async function runner(
     switch (language.toLowerCase()) {
       case 'typescript':
         generatorConfig = await typescript.config(
+          inputFilePath,
+          outputDirectory,
+          typesWriterMode,
+          groupedTypesWriterMode
+        );
+        break;
+      case 'typescript-with-decoders':
+        generatorConfig = await typescriptWithDecoders.config(
           inputFilePath,
           outputDirectory,
           typesWriterMode,

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,1 +1,2 @@
 export * as typescript from './typescript';
+export * as typescriptWithDecoders from './typescript-with-decoders';

--- a/src/templates/typescript-with-decoders/index.ts
+++ b/src/templates/typescript-with-decoders/index.ts
@@ -1,4 +1,4 @@
-import type { Configuration, TypesWriterMode, GroupedTypesWriterMode } from '$types';
+import type { Configuration, GroupedTypesWriterMode, TypesWriterMode } from '$types';
 import { readFile } from '$utils';
 
 export async function config(
@@ -8,11 +8,10 @@ export async function config(
   groupedTypesWriterMode: GroupedTypesWriterMode
 ): Promise<Configuration> {
   const devMode = '__DEVELOPMENT__'.includes('DEVELOPMENT');
-  // __DEVELOPMENT__ will be replaced with PRODUCTION when package is built.
   const directoryPrefix = devMode ? 'src/' : './';
 
   const objectSyntax = await readFile(
-    directoryPrefix + 'templates/typescript/object-syntax.hbs',
+    directoryPrefix + 'templates/typescript-with-decoders/object-syntax.hbs',
     devMode
   );
   const exporterModuleSyntax = await readFile(
@@ -20,7 +19,7 @@ export async function config(
     devMode
   );
   const typesFileSyntax = await readFile(
-    directoryPrefix + 'templates/typescript/types-file-syntax.hbs',
+    directoryPrefix + 'templates/typescript-with-decoders/types-file-syntax.hbs',
     devMode
   );
   const config: Configuration = {

--- a/src/templates/typescript-with-decoders/object-syntax.hbs
+++ b/src/templates/typescript-with-decoders/object-syntax.hbs
@@ -1,0 +1,30 @@
+export type {{typeName}} = {
+  {{#each properties}}
+  {{@key}}: {{{this.type}}}{{#unless this.required}} | null{{/unless}};
+  {{/each}}
+};
+
+export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
+  if (isJSON(rawInput)) {
+    {{#each properties}}
+    const {{@key}} = {{#if (eq this.primitiveType 'array') }} decodeArray(rawInput.{{@key}}, decode{{{toPascalCase this.composerType}}}){{else}} decode{{{toPascalCase this.type}}}(rawInput.{{@key}}){{/if}};
+    {{/each}}
+
+    {{#if (areRequiredKeysPresent properties)}}
+    if (
+      {{#each (getRequiredKeys properties)}}
+      {{this}} === null{{#unless @last}} ||{{/unless}}
+      {{/each}}
+    ) {
+      return null;
+    }
+    {{/if}}
+
+    return {
+      {{#each properties}}
+      {{@key}},
+      {{/each}}
+    };
+  }
+  return null;
+}

--- a/src/templates/typescript-with-decoders/types-file-syntax.hbs
+++ b/src/templates/typescript-with-decoders/types-file-syntax.hbs
@@ -1,0 +1,7 @@
+{{#each (getReferencedTypeModules referencedTypes writtenAt)}}
+import { {{#each this.referencedTypes}}type {{this}}, decode{{this}}{{#unless @last}}, {{/unless}} {{/each}} } from '{{this.moduleRelativePath}}';
+{{/each}}
+import { isJSON, {{#each primitives}}decode{{{toPascalCase this}}}{{#unless @last}}, {{/unless}}{{/each}} } from 'type-decoder';
+
+{{{typesContent}}}
+

--- a/src/types/decoders.ts
+++ b/src/types/decoders.ts
@@ -160,11 +160,15 @@ function decodeObjectTemplateInputProperty(rawInput: unknown): ObjectTemplateInp
     const required = decodeBoolean(rawInput.required);
     const _type = decodeString(rawInput.type);
     const referenced = decodeBoolean(rawInput.referenced);
-    if (required !== null && _type !== null && referenced !== null) {
+    const primitiveType = decodeString(rawInput.primitiveType);
+    const composerType = decodeString(rawInput.composerType);
+    if (required !== null && _type !== null && referenced !== null && primitiveType !== null) {
       return {
         type: _type,
         required,
-        referenced
+        referenced,
+        primitiveType,
+        composerType
       };
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -101,6 +101,8 @@ export type ObjectTemplateInputProperty = {
   type: string;
   required: boolean;
   referenced: boolean;
+  primitiveType: string;
+  composerType: string | null;
 };
 
 export type ExporterModuleTemplateInput = {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -36,6 +36,20 @@ export function getOptionalKeys(object: unknown): string[] {
   return nullableKeys;
 }
 
+export function getRequiredKeys(object: unknown): string[] {
+  const requiredKeys = [];
+  const properties = decodeObjectTemplateInputProperties(object);
+  if (properties !== null) {
+    for (const propertyName in properties) {
+      const property = properties[propertyName];
+      if (property.required) {
+        requiredKeys.push(propertyName);
+      }
+    }
+  }
+  return requiredKeys;
+}
+
 export function getReferencedTypes(object: unknown): string[] {
   const referencedTypes = [];
   const properties = decodeObjectTemplateInputProperties(object);
@@ -94,8 +108,19 @@ export function toPascalCase(input: string): string {
 
 export function registerTemplateHelpers(): void {
   Handlebars.registerHelper('getOptionalKeys', getOptionalKeys);
+  Handlebars.registerHelper('getRequiredKeys', getRequiredKeys);
+  Handlebars.registerHelper(
+    'areRequiredKeysPresent',
+    (object) => getRequiredKeys(object).length > 0
+  );
   Handlebars.registerHelper('getReferencedTypes', getReferencedTypes);
   Handlebars.registerHelper('getReferencedTypeModules', getReferencedTypeModules);
+  Handlebars.registerHelper('toPascalCase', toPascalCase);
+  Handlebars.registerHelper(
+    'isNonEmptyArray',
+    (value) => Array.isArray(value) && value.length === 0
+  );
+  Handlebars.registerHelper('eq', (value1, value2) => value1 === value2);
 }
 
 export function readNestedValue(json: JSONObject, keyPath: string[]): JSONObject {


### PR DESCRIPTION
- added template for typescript-with-decoders & language param to load template module
- added new template helpers: getRequiredKeys, areRequiredKeysPresent, toPascalCase, eq,  isNonEmptyArray
- updated ObjectTemplateInputProperty to contain primitive type (the original type passed from yaml) & composer types (for array elements)
- fixed issue with template file reading path in dev mode