### PR TITLE
fix: array items type for primitive data keys

### DIFF
--- a/.changeset/brown-gorillas-happen.md
+++ b/.changeset/brown-gorillas-happen.md
@@ -1,0 +1,7 @@
+---
+'type-crafter': patch
+---
+
+fix: issue with composer types of array elements in case of primitive data types
+
+- fixes issue with generated decoder for array types where items were of primitive type

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
+          cache: pnpm
 
       - name: Setting up PNPM
         uses: pnpm/action-setup@v2

--- a/examples/input.yaml
+++ b/examples/input.yaml
@@ -115,6 +115,10 @@ types:
         type: string
       name:
         type: string
+      tags:
+        type: array
+        items:
+          type: string
   TypeObjectFive:
     type: object
     required:

--- a/src/generators/generic.ts
+++ b/src/generators/generic.ts
@@ -124,7 +124,7 @@ function generateType(
       languageDataType = getLanguageDataType(propertyType, propertyFormat, propertyItems);
       result.primitives.add(propertyItems !== null ? 'Array' : languageDataType);
       if (propertyItems !== null) {
-        const itemsType = getReferenceName(propertyItems.$ref ?? '');
+        const itemsType = propertyItems.type ?? getReferenceName(propertyItems.$ref ?? '');
         result.references.add(itemsType);
         composerType = itemsType;
       }


### PR DESCRIPTION
- added correct itemsType for array items with primitive data type in composer