### PR TITLE
ci: fix node step cache param

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
-          cache: pnpm
 
       - name: Setting up PNPM
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
- remove cache param from setup nodejs step to fix failures in workflow