### PR TITLE
feat: added support for oneOf operator

### DIFF
--- a/.changeset/poor-olives-clap.md
+++ b/.changeset/poor-olives-clap.md
@@ -1,0 +1,8 @@
+---
+'type-crafter': minor
+---
+
+feat: added support for oneOf operator in spec generation
+
+- now you use oneOf operator in spec yaml
+- supported language: typescript & typescript-with-decoders

--- a/examples/input.yaml
+++ b/examples/input.yaml
@@ -2,6 +2,27 @@ info:
   version: 0.0.0
   title: Sample Typing Spec
 groupedTypes:
+  LivingBeings:
+    Human:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    Animal:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
   GroupOne:
     GroupObjectOne:
       type: object
@@ -53,6 +74,46 @@ groupedTypes:
         name:
           type: string
 types:
+  Student:
+    type: object
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+  Mammal:
+    oneOf:
+      - $ref: '#/groupedTypes/LivingBeings/Human'
+      - $ref: '#/groupedTypes/LivingBeings/Animal'
+      - type: string
+      - type: number
+      - type: string
+        format: date
+      - type: string
+        enum:
+          - sampleEnumValue1
+          - sampleEnumValue2
+      - type: object
+        required:
+          - id
+        properties:
+          id:
+            type: string
+          name:
+            type: string
+      - type: object
+        properties:
+          randomProperty:
+            type: string
+      - type: array
+        items:
+          type: string
+      - type: array
+        items:
+          $ref: '#/groupedTypes/LivingBeings/Human'
   TypeObjectTwo:
     type: object
     required:

--- a/src/generators/generic.ts
+++ b/src/generators/generic.ts
@@ -8,7 +8,9 @@ import type {
   GroupedTypesOutput,
   TypeDataType,
   GeneratedType,
-  EnumTemplateInput
+  EnumTemplateInput,
+  OneOfTemplateInput,
+  OneOfTemplateInputComposition
 } from '$types';
 import Runtime from '$runtime';
 import { toPascalCase } from '$utils';
@@ -33,51 +35,104 @@ function resolveAndGetReferenceName(reference: string): string {
   resolveReference(reference);
   return getReferenceName(reference);
 }
+type LanguageDataType = {
+  dataType: string;
+  itemType?: string;
+  references: Set<string>;
+  primitives: Set<string>;
+};
 
 function getLanguageDataType(
   dataType: TypeDataType,
   format: string | null,
   items: TypeInfo | null
-): string {
+): LanguageDataType {
+  const result: LanguageDataType = {
+    dataType,
+    references: new Set(),
+    primitives: new Set()
+  };
   const typeMapper = Runtime.getConfig().language.typeMapper ?? null;
   const mappedType = typeMapper !== null ? typeMapper[dataType] : null;
-  const itemsType =
+  const itemReference =
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+    items !== null && items.$ref !== null ? resolveAndGetReferenceName(items.$ref) : null;
+  const itemsType: LanguageDataType | null =
     // eslint-disable-next-line
     items !== null
       ? items.type !== null
         ? getLanguageDataType(items.type, items.format, items.items)
-        : items.$ref !== null
-          ? resolveAndGetReferenceName(items.$ref)
+        : itemReference !== null
+          ? {
+              dataType: itemReference,
+              references: new Set([itemReference]),
+              primitives: new Set()
+            }
           : null
       : null;
+
   const fillerPatterns = [];
   if (itemsType !== null) {
-    fillerPatterns.push({ regex: /~ItemType~/g, value: itemsType });
+    fillerPatterns.push({ regex: /~ItemType~/g, value: itemsType.dataType });
   }
 
+  let mappedTypeWithFormat: string | null = null;
+  let defaultType: string | null = null;
+
   if (typeof mappedType === 'string') {
-    return fillPatterns(mappedType, fillerPatterns);
+    result.dataType = fillPatterns(mappedType, fillerPatterns);
   } else if (isJSON(mappedType)) {
-    const defaultType = mappedType.default;
-    const mappedTypeWithFormat = mappedType[format ?? ''] ?? defaultType;
+    defaultType = mappedType.default;
+    mappedTypeWithFormat = mappedType[format ?? ''] ?? defaultType;
     if (typeof mappedTypeWithFormat === 'string') {
-      return fillPatterns(mappedTypeWithFormat, fillerPatterns);
+      result.dataType = fillPatterns(mappedTypeWithFormat, fillerPatterns);
     }
   }
-  return dataType;
+
+  /**
+   * @todo: Segregate array & variable type generation
+   */
+  const primitiveElementType =
+    items?.$ref !== null
+      ? null
+      : mappedTypeWithFormat === null
+        ? itemsType !== null
+          ? itemsType.dataType
+          : result.dataType
+        : typeof mappedType === 'string' && items?.$ref !== null
+          ? mappedType
+          : null;
+
+  if (itemsType !== null && primitiveElementType !== null) {
+    result.itemType = primitiveElementType;
+  } else if (itemsType !== null && itemReference !== null) {
+    result.itemType = itemReference;
+  }
+
+  if (itemsType !== null) {
+    result.references = new Set([...result.references, ...itemsType.references]);
+    result.primitives =
+      primitiveElementType !== null
+        ? new Set([...result.primitives, primitiveElementType])
+        : result.primitives;
+  }
+
+  return result;
 }
 
 function generateObjectType(typeName: string, typeInfo: TypeInfo): GeneratedType {
-  const result: GeneratedType = {
-    content: '',
-    references: new Set(),
-    primitives: new Set()
-  };
   const templateInput: ObjectTemplateInput = {
     typeName,
     description: typeInfo.description,
     example: typeInfo.example,
     properties: {}
+  };
+
+  const result: GeneratedType = {
+    content: '',
+    references: new Set(),
+    primitives: new Set(),
+    templateInput
   };
 
   let recursiveTypeGenOutput: GeneratedType | null = null;
@@ -126,7 +181,7 @@ function generateObjectType(typeName: string, typeInfo: TypeInfo): GeneratedType
         result.primitives.add(primitive);
       }
     } else if (propertyType !== null) {
-      languageDataType = getLanguageDataType(propertyType, propertyFormat, propertyItems);
+      languageDataType = getLanguageDataType(propertyType, propertyFormat, propertyItems).dataType;
       result.primitives.add(propertyItems !== null ? 'Array' : languageDataType);
       if (propertyItems !== null) {
         const itemsType = propertyItems.type ?? getReferenceName(propertyItems.$ref ?? '');
@@ -161,36 +216,123 @@ function generateObjectType(typeName: string, typeInfo: TypeInfo): GeneratedType
 }
 
 function generateEnumType(typeName: string, typeInfo: TypeInfo): GeneratedType {
-  const result: GeneratedType = {
-    content: '',
-    references: new Set(),
-    primitives: new Set()
-  };
   if (typeInfo.enum === null || typeInfo.enum.length === 0 || typeInfo.type === null) {
     throw new InvalidSpecFileError('Invalid enum type for: ' + typeName);
   }
   const templateInput: EnumTemplateInput = {
-    enumName: typeName,
+    typeName,
     enumType: typeInfo.type,
     values: typeInfo.enum,
     example: typeInfo.example,
     description: typeInfo.description
   };
 
+  const result: GeneratedType = {
+    content: '',
+    references: new Set(),
+    primitives: new Set(),
+    templateInput
+  };
+
   result.content = Runtime.getEnumTemplate()(templateInput);
   return result;
+}
+
+function generateOneOfTypes(typeName: string, typeInfo: TypeInfo): GeneratedType {
+  const result: GeneratedType = {
+    content: '',
+    references: new Set(),
+    primitives: new Set()
+  };
+  if (typeInfo.oneOf === null || typeInfo.oneOf.length === 0) {
+    throw new InvalidSpecFileError('Invalid oneOf type for: ' + typeName);
+  }
+  const templateInput: OneOfTemplateInput = {
+    typeName,
+    compositions: []
+  };
+
+  for (let index = 0; index < typeInfo.oneOf.length; index++) {
+    const oneOfItem = typeInfo.oneOf[index];
+    if (oneOfItem.$ref !== null) {
+      const referenceName = resolveAndGetReferenceName(oneOfItem.$ref);
+      const composition: OneOfTemplateInputComposition = {
+        source: 'referenced',
+        referencedType: referenceName
+      };
+      templateInput.compositions.push(composition);
+      result.references.add(referenceName);
+    } else {
+      const generatedType = generateType(typeName + (index + 1), oneOfItem);
+
+      if (generatedType === null) {
+        throw new InvalidSpecFileError('Invalid oneOf type for: ' + typeName);
+      }
+
+      const composition: OneOfTemplateInputComposition = {
+        dataType: oneOfItem.type,
+        templateInput: generatedType.templateInput,
+        source: 'inline',
+        content: generatedType.content
+      };
+
+      templateInput.compositions.push(composition);
+      for (const reference of generatedType.references.values()) {
+        result.references.add(reference);
+      }
+      for (const primitive of generatedType.primitives.values()) {
+        result.primitives.add(primitive);
+      }
+    }
+  }
+
+  result.content = Runtime.getOneOfTemplate()(templateInput);
+  return result;
+}
+
+function generateVariableType(typeName: string, typeInfo: TypeInfo): GeneratedType | null {
+  if (typeInfo.type === null) {
+    return null;
+  }
+  const dataType = getLanguageDataType(typeInfo.type, typeInfo.format, typeInfo.items);
+  const _primitives = [...dataType.primitives];
+  if (typeInfo.type === 'array' && dataType.references.size !== 0) {
+    _primitives.push('Array');
+  } else if (typeInfo.type !== 'array' && typeInfo.$ref === null) {
+    _primitives.push(dataType.dataType);
+  }
+
+  return {
+    content: '',
+    references: dataType.references,
+    primitives: new Set(_primitives),
+    templateInput: {
+      typeName,
+      dataType: dataType.dataType,
+      itemType: dataType.itemType,
+      primitiveType: typeInfo.type
+    }
+  };
+}
+
+function generateType(typeName: string, typeInfo: TypeInfo): GeneratedType | null {
+  if (typeInfo.type === 'object') {
+    return generateObjectType(typeName, typeInfo);
+  }
+  if (typeInfo.enum !== null) {
+    return generateEnumType(typeName, typeInfo);
+  }
+  if (typeInfo.oneOf !== null) {
+    return generateOneOfTypes(typeName, typeInfo);
+  }
+  return generateVariableType(typeName, typeInfo);
 }
 
 function generateTypes(types: Types): GeneratedTypes {
   const result: GeneratedTypes = {};
   for (const type in types) {
     const typeInfo: TypeInfo = types[type];
-    const genType =
-      typeInfo.type === 'object'
-        ? generateObjectType(type, typeInfo)
-        : typeInfo.enum !== null
-          ? generateEnumType(type, typeInfo)
-          : null;
+    const genType = generateType(type, typeInfo);
     if (genType !== null) {
       result[type] = genType;
     }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3,6 +3,7 @@ import type {
   EnumTemplateInput,
   ExporterModuleTemplateInput,
   ObjectTemplateInput,
+  OneOfTemplateInput,
   SpecFileData,
   TypeFilePath,
   TypesFileTemplateInput
@@ -16,6 +17,7 @@ let objectSyntaxTemplate: HandlebarsTemplateDelegate<ObjectTemplateInput> | null
 let exporterModuleSyntaxTemplate: HandlebarsTemplateDelegate<ExporterModuleTemplateInput> | null =
   null;
 let typesFileSyntaxTemplate: HandlebarsTemplateDelegate<TypesFileTemplateInput> | null = null;
+let oneOfSyntaxTemplate: HandlebarsTemplateDelegate<OneOfTemplateInput> | null = null;
 let enumSyntaxTemplate: HandlebarsTemplateDelegate<EnumTemplateInput> | null = null;
 let expectedOutputFiles: Map<string, TypeFilePath> | null = null;
 
@@ -47,6 +49,7 @@ function compileTemplates(): void {
   exporterModuleSyntaxTemplate = Handlebars.compile(config.template.exporterModuleSyntax);
   typesFileSyntaxTemplate = Handlebars.compile(config.template.typesFileSyntax);
   enumSyntaxTemplate = Handlebars.compile(config.template.enumSyntax);
+  oneOfSyntaxTemplate = Handlebars.compile(config.template.oneOfSyntax);
 }
 
 function getObjectTemplate(): HandlebarsTemplateDelegate<ObjectTemplateInput> {
@@ -77,6 +80,13 @@ function getEnumTemplate(): HandlebarsTemplateDelegate<EnumTemplateInput> {
   return enumSyntaxTemplate;
 }
 
+function getOneOfTemplate(): HandlebarsTemplateDelegate<OneOfTemplateInput> {
+  if (oneOfSyntaxTemplate === null) {
+    throw new RuntimeError('OneOf template not compiled!');
+  }
+  return oneOfSyntaxTemplate;
+}
+
 function setExpectedOutputFiles(newExpectedOutputFiles: Map<string, TypeFilePath>): void {
   expectedOutputFiles = newExpectedOutputFiles;
 }
@@ -99,5 +109,6 @@ export default {
   getTypesFileTemplate,
   getEnumTemplate,
   getExpectedOutputFiles,
-  compileTemplates
+  compileTemplates,
+  getOneOfTemplate
 };

--- a/src/templates/typescript-with-decoders/enum-syntax.hbs
+++ b/src/templates/typescript-with-decoders/enum-syntax.hbs
@@ -1,5 +1,5 @@
 /**
- * @type { {{enumName}} }
+ * @type { {{typeName}} }
  {{#if description}}
  * @description {{{description}}}
  {{/if}}
@@ -7,12 +7,12 @@
  * @example {{{example}}}
  {{/if}}
  */
-export type {{enumName}} =
+export type {{typeName}} =
 {{#each values}}
   | {{#if (eq ../enumType 'string') }}'{{/if}}{{{this}}}{{#if (eq ../enumType 'string')}}'{{/if}}
 {{/each}};
 
-export function decode{{enumName}}(rawInput: unknown): {{enumName}} | null {
+export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
   switch (rawInput) {
     {{#each values}}
     case {{#if (eq ../enumType 'string') }}'{{/if}}{{this}}{{#if (eq ../enumType 'string')}}'{{/if}}:

--- a/src/templates/typescript-with-decoders/index.ts
+++ b/src/templates/typescript-with-decoders/index.ts
@@ -27,6 +27,11 @@ export async function config(
     devMode
   );
 
+  const oneOfSyntax = await readFile(
+    directoryPrefix + 'templates/typescript-with-decoders/oneOf-syntax.hbs',
+    devMode
+  );
+
   const config: Configuration = {
     input: inputFilePath,
     output: {
@@ -42,7 +47,8 @@ export async function config(
       objectSyntax,
       exporterModuleSyntax,
       typesFileSyntax,
-      enumSyntax
+      enumSyntax,
+      oneOfSyntax
     },
     language: {
       exporterModuleName: 'index',

--- a/src/templates/typescript-with-decoders/oneOf-syntax.hbs
+++ b/src/templates/typescript-with-decoders/oneOf-syntax.hbs
@@ -1,0 +1,74 @@
+export type {{typeName}} =
+  {{#each compositions}}
+  | {{#if (eq this.source 'referenced')}}C{{referencedType}}
+  {{else if (eq this.source 'inline')}}
+    {{#if this.templateInput.values}}
+      {{this.templateInput.typeName}}
+    {{else if (eq this.dataType 'object')}}
+      C{{this.templateInput.typeName}}
+    {{else}}
+      {{this.templateInput.dataType}}
+    {{/if}}
+  {{/if}}
+{{/each}};
+
+export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
+  const result: {{typeName}} | null =
+  {{#each compositions}}
+  {{#if (eq this.source 'referenced')}}
+    decodeC{{referencedType}}(rawInput)
+  {{else if (eq this.dataType 'object')}}
+    decodeC{{this.templateInput.typeName}}(rawInput)
+  {{else if (eq this.templateInput.primitiveType 'array')}}
+    decodeArray(rawInput, decode{{{toPascalCase this.templateInput.itemType}}})
+  {{else if this.templateInput.values}}
+    decode{{this.templateInput.typeName}}(rawInput)
+  {{else}}
+    decode{{{toPascalCase this.templateInput.dataType}}}(rawInput)
+  {{/if}}{{#unless @last}}??{{/unless}}
+  {{/each}};
+  return result;
+}
+
+
+{{#each compositions}}
+
+{{#if this.templateInput.values}}
+{{{this.content}}}
+{{else if (eq this.source 'referenced')}}
+export class C{{referencedType}} {
+  data: {{referencedType}};
+  constructor(data: {{referencedType}}) {
+    this.data = data;
+  }
+}
+
+export function decodeC{{referencedType}}(rawInput: unknown): C{{referencedType}} | null {
+  const result = decode{{referencedType}}(rawInput);
+  if (result === null) {
+    return null;
+  }
+  return new C{{referencedType}}(result);
+}
+
+{{else if (eq this.dataType 'object')}}
+
+{{{this.content}}}
+
+export class C{{this.templateInput.typeName}} {
+  data: {{this.templateInput.typeName}};
+  constructor(data: {{this.templateInput.typeName}}) {
+    this.data = data;
+  }
+}
+
+export function decodeC{{this.templateInput.typeName}}(rawInput: unknown) {
+  const result = decode{{this.templateInput.typeName}}(rawInput);
+  if (result === null) {
+    return null;
+  }
+  return new C{{this.templateInput.typeName}}(result);
+}
+
+{{/if}}
+{{/each}}

--- a/src/templates/typescript/enum-syntax.hbs
+++ b/src/templates/typescript/enum-syntax.hbs
@@ -1,5 +1,5 @@
 /**
- * @type { {{enumName}} }
+ * @type { {{typeName}} }
  {{#if description}}
  * @description {{{description}}}
  {{/if}}
@@ -7,7 +7,7 @@
  * @example {{{example}}}
  {{/if}}
  */
-export type {{enumName}} =
+export type {{typeName}} =
 {{#each values}}
   | {{#if (eq ../enumType 'string') }}'{{/if}}{{{this}}}{{#if (eq ../enumType 'string')}}'{{/if}}
 {{/each}};

--- a/src/templates/typescript/index.ts
+++ b/src/templates/typescript/index.ts
@@ -29,6 +29,11 @@ export async function config(
     devMode
   );
 
+  const oneOfSyntax = await readFile(
+    directoryPrefix + 'templates/typescript/oneOf-syntax.hbs',
+    devMode
+  );
+
   const config: Configuration = {
     input: inputFilePath,
     output: {
@@ -44,7 +49,8 @@ export async function config(
       objectSyntax,
       exporterModuleSyntax,
       typesFileSyntax,
-      enumSyntax
+      enumSyntax,
+      oneOfSyntax
     },
     language: {
       exporterModuleName: 'index',

--- a/src/templates/typescript/oneOf-syntax.hbs
+++ b/src/templates/typescript/oneOf-syntax.hbs
@@ -1,0 +1,19 @@
+export type {{typeName}} =
+  {{#each compositions}}
+  | {{#if (eq this.source 'referenced')}}{{referencedType}}
+  {{else if (eq this.source 'inline')}}
+    {{#if this.templateInput.values}}
+      {{#each this.templateInput.values}}
+        {{#unless @first}}|{{/unless}} {{#if (eq ../this.templateInput.enumType 'string') }}'{{/if}}{{{this}}}{{#if (eq ../this.templateInput/enumType 'string')}}'{{/if}}
+      {{/each}}
+    {{else if (eq this.dataType 'object')}}
+      {
+        {{#each this.templateInput.properties}}
+        {{@key}}: {{{this.type}}}{{#unless this.required}} | null{{/unless}};
+        {{/each}}
+      }
+    {{else}}
+      {{this.templateInput.dataType}}
+    {{/if}}
+  {{/if}}
+{{/each}};

--- a/src/types/decoders.ts
+++ b/src/types/decoders.ts
@@ -121,6 +121,7 @@ function decodeTypeInfo(rawInput: unknown): TypeInfo | null {
       $ref: decodeString(rawInput.$ref),
       description: decodeString(rawInput.description),
       example: decodeString(rawInput.example) ?? decodeNumber(rawInput.example),
+      oneOf: decodeArray(rawInput.oneOf, decodeTypeInfo),
       enum:
         _type === 'string'
           ? decodeArray(rawInput.enum, decodeString)
@@ -211,14 +212,14 @@ export function decodeObjectTemplateInputProperties(
 
 export function decodeEnumTemplateInput(rawInput: unknown): EnumTemplateInput | null {
   if (isJSON(rawInput)) {
-    const enumName = decodeString(rawInput.enumName);
+    const typeName = decodeString(rawInput.typeName);
     const enumType = decodeString(rawInput.enumType);
     const values = decodeArray(rawInput.values, decodeString);
     const example = decodeString(rawInput.example);
     const description = decodeString(rawInput.description);
-    if (enumName !== null && values !== null && enumType !== null) {
+    if (typeName !== null && values !== null && enumType !== null) {
       return {
-        enumName,
+        typeName,
         enumType,
         values,
         example,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,7 @@ export type Template = {
   exporterModuleSyntax: string;
   typesFileSyntax: string;
   enumSyntax: string;
+  oneOfSyntax: string;
 };
 
 export type LanguageConfig = {
@@ -73,6 +74,7 @@ export type TypeInfo = {
   items: TypeInfo | null;
   properties: TypeProperties | null;
   $ref: string | null;
+  oneOf: TypeInfo[] | null;
   enum: string[] | number[] | null;
   description: string | null;
   example: string | number | null;
@@ -131,12 +133,34 @@ export type ReferencedModule = {
 };
 
 export type EnumTemplateInput = {
-  enumName: string;
+  typeName: string;
   enumType: string;
   values: string[] | number[];
   example: string | number | null;
   description: string | null;
 };
+
+export type OneOfTemplateInput = {
+  typeName: string;
+  compositions: OneOfTemplateInputComposition[];
+};
+
+export type OneOfTemplateInputComposition = {
+  dataType?: TypeDataType | null;
+  templateInput?: TemplateInput;
+  source: 'inline' | 'referenced';
+  referencedType?: string;
+  content?: string;
+};
+
+export type VariableTemplateInput = {
+  typeName: string;
+  dataType: string;
+  primitiveType: string;
+  itemType?: string;
+};
+
+export type TemplateInput = ObjectTemplateInput | EnumTemplateInput | VariableTemplateInput;
 
 // #endregion
 
@@ -146,7 +170,14 @@ export type GenerationResult = {
   groupedTypes: GroupedTypesOutput;
   types: GeneratedTypes;
 };
-export type GeneratedType = { content: string; references: Set<string>; primitives: Set<string> };
+
+export type GeneratedType = {
+  content: string;
+  references: Set<string>;
+  primitives: Set<string>;
+  templateInput?: TemplateInput;
+};
+
 export type GroupedTypesOutput = Record<GroupName, GeneratedTypes>;
 export type GeneratedTypes = Record<TypeName, GeneratedType>;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -106,6 +106,14 @@ export function toPascalCase(input: string): string {
     .join('');
 }
 
+export function toPascalCaseHelper(input: unknown): string | unknown {
+  const inputString = decodeString(input);
+  if (inputString === null) {
+    return input;
+  }
+  return toPascalCase(inputString);
+}
+
 export function registerTemplateHelpers(): void {
   Handlebars.registerHelper('getOptionalKeys', getOptionalKeys);
   Handlebars.registerHelper('getRequiredKeys', getRequiredKeys);
@@ -115,7 +123,7 @@ export function registerTemplateHelpers(): void {
   );
   Handlebars.registerHelper('getReferencedTypes', getReferencedTypes);
   Handlebars.registerHelper('getReferencedTypeModules', getReferencedTypeModules);
-  Handlebars.registerHelper('toPascalCase', toPascalCase);
+  Handlebars.registerHelper('toPascalCase', toPascalCaseHelper);
   Handlebars.registerHelper(
     'isNonEmptyArray',
     (value) => Array.isArray(value) && value.length === 0


### PR DESCRIPTION
- added support for oneOf operator in spec input
- added template & interpreter for oneOf operator
- fixed toPascalCase template helper to handled undefined values
- added support for generating variable types
- updated typescript & typescript-with-decoders templates to generate types with oneOf
- updated geneartor methods to include template input in response returned (helpful in resuability of fn)
- hacked way out of generating types for array; to be fixed later
- added examples to examples/input.yaml for demonstrating oneOf usage