### PR TITLE
fix: type written references in case of folder with files write mode

### DIFF
--- a/.changeset/unlucky-rings-hammer.md
+++ b/.changeset/unlucky-rings-hammer.md
@@ -1,0 +1,7 @@
+---
+'type-crafter': patch
+---
+
+fix: reference generation for FolderWithFiles writer mode for GroupedTypes
+
+- Issues with missing type imports in case of FolderWithFiles Group writer mode is now fixed

--- a/docs/procedure-descriptions.md
+++ b/docs/procedure-descriptions.md
@@ -1,0 +1,30 @@
+# Procedure descriptions
+
+This file contains descriptions of the procedures that are used in the project.
+This only serves as a reference for dos and don'ts, function behavior, and notes for all methods in generic generator.
+
+## Methods
+
+1. `getPrimitiveType` :
+
+   - Maps the type to native type of the language
+   - The most basic type of the language
+   - Supposed to not return any references
+   - Type cannot be a referenced type
+
+2. `generateEnumType`:
+
+   - Maps to the enum type of the language
+   - Supposed to not return any references
+   - Type cannot be a referenced type
+
+3. `generateArrayType`:
+
+   - Maps to the array type of the language
+   - Can contain references in the items type
+   - Must return all references it child has
+
+4. `generateVariableType`:
+
+   - Maps to the variable type of the language
+   - Cannot contain references

--- a/src/generators/generic.ts
+++ b/src/generators/generic.ts
@@ -122,7 +122,7 @@ async function generateObjectType(
       isReferenced = true;
     } else if (enumValues !== null) {
       const enumName = toPascalCase(propertyName) + 'Enum';
-      dynamicGeneratedType = generateEnumType(enumName, propertyDetails).content;
+      dynamicGeneratedType += generateEnumType(enumName, propertyDetails).content;
       languageDataType = enumName;
     } else if (propertyType === 'array') {
       const arrayDataGenOutput = await generateArrayType(
@@ -153,7 +153,7 @@ async function generateObjectType(
       languageDataType = primitiveTypeGenOutput.templateInput.type;
       primitives.push(...primitiveTypeGenOutput.primitives);
       references.push(...primitiveTypeGenOutput.references);
-      dynamicGeneratedType = primitiveTypeGenOutput.content;
+      dynamicGeneratedType += primitiveTypeGenOutput.content;
     }
 
     if (languageDataType === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,8 +97,8 @@ program
   .argument('<outputLanguage>', 'Language to generate types for')
   .argument('<inputFilePath>', 'Path to the input spec file')
   .argument('<outputDirectory>', 'Path to the output file')
-  .argument('[typesWriterMode]', 'Writer mode for types', 'Files')
-  .argument('[groupedTypesWriterMode]', 'Writer mode for grouped types', 'FolderWithFiles')
+  .argument('[typesWriterMode]', 'Writer mode for types', 'SingleFile')
+  .argument('[groupedTypesWriterMode]', 'Writer mode for grouped types', 'SingleFile')
   .action(runner);
 
 program.parse();

--- a/src/writer/index.ts
+++ b/src/writer/index.ts
@@ -38,7 +38,8 @@ async function writeTypesToFiles(
   // Filtering references for writing types to files; Done for types.writerMode: Files
   // Maybe a hack. But it works for now
   // Fix this later
-  const filterReferences = folderName !== '';
+  const filterReferences =
+    folderName !== '' && Runtime.getConfig().output.writerMode.groupedTypes !== 'FolderWithFiles';
 
   const typeNames = Object.keys(types);
 


### PR DESCRIPTION
- preventing filtering in case folder with files write mode for group to avoid missing references
- fix missing dynamically generated types in case of object generation