### PR TITLE
fix: references in generated output

### DIFF
--- a/.changeset/spicy-candles-try.md
+++ b/.changeset/spicy-candles-try.md
@@ -1,0 +1,8 @@
+---
+'type-crafter': patch
+---
+
+fix: conflicting type name & missing imports in generated output
+
+- fixed issues with conflicting types in same file & missing type imports in generated output
+- made filename case sensitive fro avoiding same types written in two different files with different naming case

--- a/src/templates/typescript-with-decoders/object-syntax.hbs
+++ b/src/templates/typescript-with-decoders/object-syntax.hbs
@@ -7,7 +7,7 @@
  * @example {{{example}}}
  {{/if}}
  */
-export type {{typeName}} = {
+export type {{typeName}} = {{#if (not (isEmptyObject properties))}}  {
   {{#each properties}}
   /**
   {{#if this.description}}
@@ -25,6 +25,9 @@ export type {{typeName}} = {
   [keys: {{jsonKey additionalProperties.keyType}}]: {{additionalProperties.valueType}};
   {{/if}}
 };
+{{else if (or (notEq length additionalProperties 0) (not (isEmptyObject additionalProperties)))}}
+Record<{{jsonKey additionalProperties.keyType}}, {{additionalProperties.valueType}}>;
+{{/if}}
 
 export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
   if (isJSON(rawInput)) {

--- a/src/templates/typescript-with-decoders/oneOf-syntax.hbs
+++ b/src/templates/typescript-with-decoders/oneOf-syntax.hbs
@@ -1,11 +1,11 @@
 export type {{typeName}} =
   {{#each compositions}}
-  | {{#if (eq this.source 'referenced')}}C{{referencedType}}
+  | {{#if (eq this.source 'referenced')}}C{{../typeName}}{{referencedType}}
   {{else if (eq this.source 'inline')}}
     {{#if this.templateInput.values}}
       {{this.templateInput.typeName}}
     {{else if (eq this.dataType 'object')}}
-      C{{this.templateInput.typeName}}
+      C{{typeName}}{{this.templateInput.typeName}}
     {{else}}
       {{this.templateInput.type}}
     {{/if}}
@@ -16,7 +16,7 @@ export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
   const result: {{typeName}} | null =
   {{#each compositions}}
   {{#if (eq this.source 'referenced')}}
-    decodeC{{referencedType}}(rawInput)
+    decodeC{{../typeName}}{{referencedType}}(rawInput)
   {{else if (eq this.dataType 'object')}}
     decodeC{{this.templateInput.typeName}}(rawInput)
   {{else if (eq this.dataType 'array')}}
@@ -36,26 +36,26 @@ export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
 {{#if this.templateInput.values}}
 {{{this.content}}}
 {{else if (eq this.source 'referenced')}}
-export class C{{referencedType}} {
+export class C{{../typeName}}{{referencedType}} {
   data: {{referencedType}};
   constructor(data: {{referencedType}}) {
     this.data = data;
   }
 }
 
-export function decodeC{{referencedType}}(rawInput: unknown): C{{referencedType}} | null {
+export function decodeC{{../typeName}}{{referencedType}}(rawInput: unknown): C{{../typeName}}{{referencedType}} | null {
   const result = decode{{referencedType}}(rawInput);
   if (result === null) {
     return null;
   }
-  return new C{{referencedType}}(result);
+  return new C{{../typeName}}{{referencedType}}(result);
 }
 
 {{else if (eq this.dataType 'object')}}
 
 {{{this.content}}}
 
-export class C{{this.templateInput.typeName}} {
+export class C{{../typeName}}{{this.templateInput.typeName}} {
   data: {{this.templateInput.typeName}};
   constructor(data: {{this.templateInput.typeName}}) {
     this.data = data;
@@ -67,7 +67,7 @@ export function decodeC{{this.templateInput.typeName}}(rawInput: unknown) {
   if (result === null) {
     return null;
   }
-  return new C{{this.templateInput.typeName}}(result);
+  return new C{{../typeName}}{{this.templateInput.typeName}}(result);
 }
 
 {{/if}}

--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -16,10 +16,21 @@ export function resolveFilePath(filePath: string, useCurrentDirectory: boolean =
   return path.resolve(normalizedPath);
 }
 
+async function checkFileNameCase(filePath: string): Promise<boolean> {
+  const directory = path.dirname(filePath);
+  const fileName = path.basename(filePath);
+
+  const files = await fs.readdir(directory);
+  return files.includes(fileName);
+}
+
 export async function readFile(
   filePath: string,
   useCurrentWorkingDirectory: boolean = true
 ): Promise<string> {
+  if (!(await checkFileNameCase(filePath))) {
+    throw new Error(`File not found: ${filePath}`);
+  }
   const data = await fs.readFile(resolveFilePath(filePath, useCurrentWorkingDirectory), 'utf-8');
   return data;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -151,9 +151,25 @@ export function registerTemplateHelpers(): void {
     (value: unknown) => Array.isArray(value) && value.length === 0
   );
   Handlebars.registerHelper('eq', (value1: unknown, value2: unknown) => value1 === value2);
+  Handlebars.registerHelper('notEq', (value1: unknown, value2: unknown) => value1 !== value2);
+  Handlebars.registerHelper(
+    'isEmptyObject',
+    (value: unknown) =>
+      typeof value === 'object' && value !== null && Object.keys(value).length === 0
+  );
   Handlebars.registerHelper('jsonKey', refineJSONKey);
   Handlebars.registerHelper('variableName', refineVariableName);
   Handlebars.registerHelper('indexKey', refineIndexKey);
+  Handlebars.registerHelper('not', (value: unknown) => {
+    if (typeof value === 'boolean') {
+      return !value;
+    }
+  });
+  Handlebars.registerHelper('or', (value1: unknown, value2: unknown) => {
+    if (typeof value1 === 'boolean' && typeof value2 === 'boolean') {
+      return value1 || value2;
+    }
+  });
 }
 
 export function readNestedValue(json: unknown, keyPath: string[]): JSONObject {


### PR DESCRIPTION
- fixed issues with missing references in the template input & generated output
- fixed typescript-with-decoders template for avoiding conflicting typenames for oneOf
- added strict checking for file name case for avoiding conflicting definitions written in diff files with diff file filename case