### PR TITLE
fix: rs object key naming & ts gen output

### DIFF
--- a/src/generators/generic.ts
+++ b/src/generators/generic.ts
@@ -101,18 +101,19 @@ async function generateAdditionalPropertiesType(
     type: 'string'
   }).templateInput.type;
   if (typeof typeInfo.additionalProperties === 'boolean') {
+    const unknownType = getPrimitiveType(typeName, {
+      ...placeholderTypeInfo,
+      type: 'unknown'
+    });
     return {
       templateInput: {
         keyType: stringKeyType,
-        valueType: getPrimitiveType(typeName, {
-          ...placeholderTypeInfo,
-          type: 'unknown'
-        }).templateInput.type,
+        valueType: unknownType.templateInput.type,
         valueTypeReferenced: false,
         valuePrimitiveType: 'unknown',
         valueComposerType: null
       },
-      primitives: new Set<string>()
+      primitives: unknownType.primitives
     };
   } else if (valueIsKeyedAdditionalProperties(typeInfo.additionalProperties)) {
     const valueTypeInfo = typeInfo.additionalProperties.valueType;

--- a/src/templates/rust/object-syntax.hbs
+++ b/src/templates/rust/object-syntax.hbs
@@ -10,7 +10,9 @@ pub struct {{typeName}} {
 {{#if this.description}}
     /// {{{this.description}}}
 {{/if}}
+{{#unless (eq @key (toSnakeCase @key))}}
     #[serde(rename = "{{@key}}")]
+{{/unless}}
 {{#unless this.required}}
     #[serde(skip_serializing_if = "Option::is_none")]
 {{/unless}}


### PR DESCRIPTION
- fix object key naming in rust templates to avoid redundant key renaming for snake_case keys
- fix import params for decoders in ts-with-decoders generator