### PR TITLE
feat: add support for skip decoder gen for allOf, enum, oneOf

### DIFF
--- a/src/generators/generic.ts
+++ b/src/generators/generic.ts
@@ -332,7 +332,8 @@ function generateEnumType(typeName: string, typeInfo: TypeInfo): GeneratedType<E
     values: typeInfo.enum,
     example: typeInfo.example,
     description: typeInfo.description,
-    summary: typeInfo.summary
+    summary: typeInfo.summary,
+    customAttributes: typeInfo.customAttributes ?? null
   };
 
   const result: GeneratedType<EnumTemplateInput> = {
@@ -511,7 +512,8 @@ async function generateOneOfTypes(
     compositions: [],
     description: typeInfo.description,
     example: typeInfo.example,
-    summary: typeInfo.summary
+    summary: typeInfo.summary,
+    customAttributes: typeInfo.customAttributes ?? null
   };
 
   const result: GeneratedType<OneOfTemplateInput> = {
@@ -577,7 +579,8 @@ async function generateAllOfTypes(
     compositions: [],
     description: typeInfo.description,
     example: typeInfo.example,
-    summary: typeInfo.summary
+    summary: typeInfo.summary,
+    customAttributes: typeInfo.customAttributes ?? null
   };
 
   const result: GeneratedType<AllOfTemplateInput> = {

--- a/src/templates/typescript-with-decoders/allOf-syntax.hbs
+++ b/src/templates/typescript-with-decoders/allOf-syntax.hbs
@@ -18,6 +18,7 @@ export type {{typeName}} =
 {{/if}}
 {{/each}}
 
+{{#unless customAttributes.skipDecoderGeneration}}
 export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
   {{#each compositions}}
   {{#if (eq this.source 'referenced')}}
@@ -40,3 +41,4 @@ export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
     }
   return null;
 }
+{{/unless}}

--- a/src/templates/typescript-with-decoders/enum-syntax.hbs
+++ b/src/templates/typescript-with-decoders/enum-syntax.hbs
@@ -12,6 +12,7 @@ export type {{typeName}} =
   | {{#if (eq ../type 'string') }}'{{/if}}{{{this}}}{{#if (eq ../type 'string')}}'{{/if}}
 {{/each}};
 
+{{#unless customAttributes.skipDecoderGeneration}}
 export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
   switch (rawInput) {
     {{#each values}}
@@ -21,7 +22,9 @@ export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
   }
   return null;
 }
+{{/unless}}
 
+{{#if customAttributes.generateOptionalDecoder}}
 export function _decode{{typeName}}(rawInput: unknown): {{typeName}} | undefined {
   switch (rawInput) {
     {{#each values}}
@@ -31,3 +34,4 @@ export function _decode{{typeName}}(rawInput: unknown): {{typeName}} | undefined
   }
   return;
 }
+{{/if}}

--- a/src/templates/typescript-with-decoders/oneOf-syntax.hbs
+++ b/src/templates/typescript-with-decoders/oneOf-syntax.hbs
@@ -19,6 +19,7 @@ export type {{typeName}} =
   {{/if}}
 {{/each}};
 
+{{#unless customAttributes.skipDecoderGeneration}}
 export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
   const result: {{typeName}} | null =
   {{#each compositions}}
@@ -36,6 +37,7 @@ export function decode{{typeName}}(rawInput: unknown): {{typeName}} | null {
   {{/each}};
   return result;
 }
+{{/unless}}
 
 
 {{#each compositions}}
@@ -50,6 +52,7 @@ export class C{{../typeName}}{{referencedType}} {
   }
 }
 
+{{#unless ../customAttributes.skipDecoderGeneration}}
 export function decodeC{{../typeName}}{{referencedType}}(rawInput: unknown): C{{../typeName}}{{referencedType}} | null {
   const result = decode{{referencedType}}(rawInput);
   if (result === null) {
@@ -57,6 +60,7 @@ export function decodeC{{../typeName}}{{referencedType}}(rawInput: unknown): C{{
   }
   return new C{{../typeName}}{{referencedType}}(result);
 }
+{{/unless}}
 
 {{else if (eq this.dataType 'object')}}
 
@@ -69,6 +73,7 @@ export class C{{../typeName}}{{this.templateInput.typeName}} {
   }
 }
 
+{{#unless ../customAttributes.skipDecoderGeneration}}
 export function decodeC{{this.templateInput.typeName}}(rawInput: unknown) {
   const result = decode{{this.templateInput.typeName}}(rawInput);
   if (result === null) {
@@ -76,6 +81,7 @@ export function decodeC{{this.templateInput.typeName}}(rawInput: unknown) {
   }
   return new C{{../typeName}}{{this.templateInput.typeName}}(result);
 }
+{{/unless}}
 
 {{/if}}
 {{/each}}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -222,12 +222,14 @@ export type EnumTemplateInput = TypeDescriptors & {
   typeName: string;
   type: string;
   values: string[] | number[];
+  customAttributes?: Record<string, unknown> | null;
 };
 
 export type OneOfTemplateInput = TypeDescriptors & {
   typeName: string;
   type: string;
   compositions: OneOfTemplateInputComposition[];
+  customAttributes?: Record<string, unknown> | null;
 };
 
 export type OneOfTemplateInputComposition = {
@@ -242,6 +244,7 @@ export type AllOfTemplateInput = TypeDescriptors & {
   typeName: string;
   type: string;
   compositions: AllOfTemplateInputComposition[];
+  customAttributes?: Record<string, unknown> | null;
 };
 
 export type AllOfTemplateInputComposition = {


### PR DESCRIPTION
- added support for skip decoder gen for allOf, enum, oneOf in typescript-with-decoders generator
- fixed non generation of optional decoder in enum