### PR TITLE
fix: exclude exporter module from its own pub mod list

### DIFF
--- a/src/writer/index.ts
+++ b/src/writer/index.ts
@@ -109,6 +109,7 @@ async function writeExporterModules(files: Set<string>, folder: string): Promise
   const exporterModuleContent = Runtime.getExporterModuleTemplate()({
     modules: [...files]
       .map((file) => file.replace(Runtime.getConfig().output.fileExtension, ''))
+      .filter((name) => name !== Runtime.getConfig().language.exporterModuleName)
       .sort()
   });
   const config = Runtime.getConfig();


### PR DESCRIPTION
When generating Rust types in SingleFile mode, the exporter module (mod.rs) includes itself in the `pub mod` declarations, producing `pub mod mod;` which is invalid Rust — `mod` is a reserved keyword and it creates a self-referencing module.

Filter out the exporter module name from the modules list before generating the pub mod declarations.