### PR TITLE
fix: alphabetical order for serde derives in Rust templates

### DIFF
--- a/src/templates/rust/allOf-syntax.hbs
+++ b/src/templates/rust/allOf-syntax.hbs
@@ -1,7 +1,7 @@
 {{#if description}}
 /// {{{description}}}
 {{/if}}
-#[derive({{{appendUnique "Debug, Clone, Serialize, Deserialize" customAttributes.[x-derive]}}})]
+#[derive({{{appendUnique "Debug, Clone, Deserialize, Serialize" customAttributes.[x-derive]}}})]
 {{#each customAttributes.[x-attributes]}}
 #[{{{this}}}]
 {{/each}}

--- a/src/templates/rust/enum-syntax.hbs
+++ b/src/templates/rust/enum-syntax.hbs
@@ -4,7 +4,7 @@
 {{#if example}}
 /// Example: {{{example}}}
 {{/if}}
-#[derive({{{appendUnique "Debug, Clone, Serialize, Deserialize" customAttributes.[x-derive]}}})]
+#[derive({{{appendUnique "Debug, Clone, Deserialize, Serialize" customAttributes.[x-derive]}}})]
 {{#each customAttributes.[x-attributes]}}
 #[{{{this}}}]
 {{/each}}

--- a/src/templates/rust/object-syntax.hbs
+++ b/src/templates/rust/object-syntax.hbs
@@ -4,7 +4,7 @@
 {{#if example}}
 /// Example: {{{example}}}
 {{/if}}
-#[derive({{{appendUnique "Debug, Clone, Serialize, Deserialize" customAttributes.[x-derive]}}})]
+#[derive({{{appendUnique "Debug, Clone, Deserialize, Serialize" customAttributes.[x-derive]}}})]
 {{#each customAttributes.[x-attributes]}}
 #[{{{this}}}]
 {{/each}}

--- a/src/templates/rust/oneOf-syntax.hbs
+++ b/src/templates/rust/oneOf-syntax.hbs
@@ -1,7 +1,7 @@
 {{#if description}}
 /// {{{description}}}
 {{/if}}
-#[derive({{{appendUnique "Debug, Clone, Serialize, Deserialize" customAttributes.[x-derive]}}})]
+#[derive({{{appendUnique "Debug, Clone, Deserialize, Serialize" customAttributes.[x-derive]}}})]
 {{#each customAttributes.[x-attributes]}}
 #[{{{this}}}]
 {{/each}}

--- a/src/templates/rust/types-file-syntax.hbs
+++ b/src/templates/rust/types-file-syntax.hbs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 {{#each (getReferencedTypeModules referencedTypes writtenAt)}}
 {{#each this.referencedTypes}}
 {{#if ../fileBasedModules}}


### PR DESCRIPTION
cargo fmt requires alphabetical order: `Deserialize, Serialize` not `Serialize, Deserialize`. Fixed in use statement and all derive macros across object, enum, allOf, and oneOf templates.