### PR TITLE
fix: remove extra newline between generated type blocks

### DIFF
--- a/src/writer/index.ts
+++ b/src/writer/index.ts
@@ -88,7 +88,7 @@ async function writeTypesToFile(
     // Removing references that are already written to file
     const _references = [...types[typeName].references].filter((x) => !typeNames.includes(x));
     templateInput.referencedTypes.push(..._references);
-    templateInput.typesContent += types[typeName].content + '\n';
+    templateInput.typesContent += types[typeName].content;
   }
 
   // remove duplicates


### PR DESCRIPTION
Each type's content already ends with a newline from the template. Remove the extra '\n' appended in the loop to avoid double blank lines between types and a trailing blank line at the end.