### PR TITLE
feat: add support for alias in rust template

### DIFF
--- a/mcp/src/docs/RULES_TYPES.md
+++ b/mcp/src/docs/RULES_TYPES.md
@@ -379,6 +379,46 @@ Notes on `x-attributes`:
 - Each entry must be the attribute's inner content only (`sqlx(...)`, `serde(deny_unknown_fields)`) — do **not** include the `#[...]` wrapper; the template adds it.
 - Entries are emitted verbatim and are not validated — invalid Rust in an entry produces invalid generated code.
 
+### On an Enum (e.g. extra accepted values)
+
+`x-alias` lets an enum variant accept additional values when deserializing. It is a map keyed by the **spec enum value**, where each entry is a **list** of aliases:
+
+```yaml
+Runner:
+  type: string
+  enum:
+    - alpha_runner
+    - beta_runner
+  customAttributes:
+    x-alias:
+      alpha_runner:
+        - alphaRunner
+        - ALPHA
+```
+
+The Rust template emits one `#[serde(alias = "…")]` line per alias, below the variant's `#[serde(rename = "…")]`:
+
+```rust
+pub enum Runner {
+    #[serde(rename = "alpha_runner")]
+    #[serde(alias = "alphaRunner")]
+    #[serde(alias = "ALPHA")]
+    AlphaRunner,
+    #[serde(rename = "beta_runner")]
+    BetaRunner,
+}
+```
+
+Use it to accept legacy or alternately-cased payloads without changing the type. Serialization is unaffected — the variant is still written using its canonical enum value.
+
+Notes on `x-alias`:
+
+- Supported on enums only (both `type: string` and `type: number`), and **Rust only** — other language templates ignore it.
+- Works on standalone enums and on inline enums declared under an object property.
+- Each entry must be a list. A bare string is ignored, as with `x-derive` and `x-attributes`.
+- Aliases are emitted verbatim and are not validated — an alias that collides with another variant's value produces code that fails to compile.
+- Keys that do not match an enum value are silently ignored.
+
 ### On a Union (e.g. shorter wrapper class names) — TypeScript only
 
 > **Supported only for TypeScript generation** (the `typescript-with-decoders` template). The `rust` and other language templates do not emit these wrapper classes and ignore this attribute entirely.

--- a/mcp/src/docs/WRITING_GUIDE.md
+++ b/mcp/src/docs/WRITING_GUIDE.md
@@ -52,14 +52,14 @@ Type Crafter generates typed code from YAML specifications. This guide is the de
 
 #### On a primitive (`type: string | number | integer | boolean | unknown`)
 
-| Keyword            | Required | Description                                                                                        |
-| ------------------ | -------- | -------------------------------------------------------------------------------------------------- |
-| `type`             | Yes      | One of: `string`, `number`, `integer`, `boolean`, `unknown`                                        |
-| `enum`             | No       | Array of allowed values. Creates a union of literals.                                              |
-| `format`           | No       | `date` or `date-time`, only on `type: string`                                                      |
-| `customAttributes` | No       | Pass-through key/value map for template-level features (e.g. `x-name`, `x-derive`, `x-attributes`) |
-| `description`      | No       | Documentation comment                                                                              |
-| `example`          | No       | Documentation example                                                                              |
+| Keyword            | Required | Description                                                                                                   |
+| ------------------ | -------- | ------------------------------------------------------------------------------------------------------------- |
+| `type`             | Yes      | One of: `string`, `number`, `integer`, `boolean`, `unknown`                                                   |
+| `enum`             | No       | Array of allowed values. Creates a union of literals.                                                         |
+| `format`           | No       | `date` or `date-time`, only on `type: string`                                                                 |
+| `customAttributes` | No       | Pass-through key/value map for template-level features (e.g. `x-name`, `x-derive`, `x-attributes`, `x-alias`) |
+| `description`      | No       | Documentation comment                                                                                         |
+| `example`          | No       | Documentation example                                                                                         |
 
 #### On an object (`type: object`)
 
@@ -97,7 +97,7 @@ Type Crafter generates typed code from YAML specifications. This guide is the de
 
 **No other keywords exist anywhere.** Do not use `nullable`, `optional`, `extensible`, `default`, `minimum`, `maximum`, `minLength`, `maxLength`, `pattern`, `title` (on properties), `readOnly`, `writeOnly`, `deprecated`, `discriminator`, `allowed_values`, `values`, `options`, `choices`, or anything from OpenAPI/JSON Schema that is not listed above.
 
-> **Note on `customAttributes`:** This field is a generic pass-through map. Its keys/values are not validated by Type Crafter — they are forwarded directly to language templates. Different language templates may read different keys (e.g. the Rust template reads `x-name` for serde rename, `renameAll` for `serde(rename_all)`, `x-derive` to append custom `#[derive(...)]` macros, and `x-attributes` to emit raw container attributes such as `#[sqlx(type_name = "text")]`). Consult the template documentation for your target language.
+> **Note on `customAttributes`:** This field is a generic pass-through map. Its keys/values are not validated by Type Crafter — they are forwarded directly to language templates. Different language templates may read different keys (e.g. the Rust template reads `x-name` for serde rename, `renameAll` for `serde(rename_all)`, `x-derive` to append custom `#[derive(...)]` macros, `x-attributes` to emit raw container attributes such as `#[sqlx(type_name = "text")]`, and — on enums — `x-alias` to accept extra values via `#[serde(alias = "…")]`). Consult the template documentation for your target language.
 
 ---
 

--- a/src/templates/rust/enum-syntax.hbs
+++ b/src/templates/rust/enum-syntax.hbs
@@ -12,6 +12,11 @@ pub enum {{typeName}} {
 {{#each values}}
 {{#if (eq ../type 'string')}}
     #[serde(rename = "{{this}}")]
+{{/if}}
+{{#each (lookup ../customAttributes.[x-alias] this)}}
+    #[serde(alias = "{{{this}}}")]
+{{/each}}
+{{#if (eq ../type 'string')}}
     {{{toPascalCase this}}},
 {{else}}
     Value{{{this}}},


### PR DESCRIPTION
- added support for aliases for enums in rust template.
- updated mcp documentation